### PR TITLE
Fix fatal error on plugin activation by moving hooks

### DIFF
--- a/wasmer/wasmer.php
+++ b/wasmer/wasmer.php
@@ -75,20 +75,6 @@ add_action('rest_api_init', function () {
 // Hook to add a menu to the admin top bar
 add_action('admin_bar_menu', 'wasmer_add_top_bar_menu', 100);
 
-// Activation hook
-register_activation_hook(__FILE__, 'wasmer_plugin_activate');
-function wasmer_plugin_activate()
-{
-  // Code to run on activation, e.g., setting default options.
-}
-
-// Deactivation hook
-register_deactivation_hook(__FILE__, 'wasmer_plugin_deactivate');
-function wasmer_plugin_deactivate()
-{
-  // Code to run on deactivation, e.g., cleaning up options.
-}
-
 /**
  * Bypass Password-Protected Plugins to allow for REST API exceptions.
  *

--- a/wp-wasmer.php
+++ b/wp-wasmer.php
@@ -55,3 +55,17 @@ function wp_wasmer_display_php_version_notice() {
 }
 
 wp_wasmer_load();
+
+// Activation hook
+register_activation_hook(__FILE__, 'wasmer_plugin_activate');
+function wasmer_plugin_activate()
+{
+  // Code to run on activation, e.g., setting default options.
+}
+
+// Deactivation hook
+register_deactivation_hook(__FILE__, 'wasmer_plugin_deactivate');
+function wasmer_plugin_deactivate()
+{
+  // Code to run on deactivation, e.g., cleaning up options.
+}


### PR DESCRIPTION
The `register_activation_hook` and `register_deactivation_hook` functions were being called from `wasmer/wasmer.php`, which is an included file. In WordPress, these hooks must be called from the main plugin file.

This commit moves the activation and deactivation hooks to the main plugin file, `wp-wasmer.php`, to ensure they are registered correctly and prevent the fatal error on plugin activation.