### PR TITLE
fix: Add permission callbacks to REST API routes for public access

### DIFF
--- a/wasmer/wasmer.php
+++ b/wasmer/wasmer.php
@@ -59,14 +59,17 @@ add_action('rest_api_init', function () {
   register_rest_route('wasmer/v1', '/liveconfig', array(
     'methods' => 'GET',
     'callback' => 'wasmer_liveconfig_callback',
+    'permission_callback' => '__return_true',
   ));
   register_rest_route('wasmer/v1', '/check', array(
     'methods' => 'GET',
     'callback' => 'wasmer_check_callback',
+    'permission_callback' => '__return_true',
   ));
   register_rest_route('wasmer/v1', '/magiclogin', array(
     'methods' => 'GET',
     'callback' => 'wasmer_magiclogin_callback',
+    'permission_callback' => '__return_true',
   ));
 });
 


### PR DESCRIPTION
Since WordPress 5.5 function `register_rest_route` requires additional parameter `permission_callback`. Without that users see notice errors during development and site editing

```
Notice: Function register_rest_route was called incorrectly. The REST API route definition for wasmer/v1/liveconfig is missing
the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the
permission callback. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.)
in /app/wp-includes/functions.php on line 6131
```