### PR TITLE
fix: Use get_query_var to avoid extra warnings when rest_route is not set

### DIFF
--- a/wasmer/tests/wasmer.test.js
+++ b/wasmer/tests/wasmer.test.js
@@ -16,7 +16,7 @@ const PORT = process.env.PORT || 8080;
 const HOST = "127.0.0.1";
 const SERVER_URL = `http://${HOST}:${PORT}`;
 
-const LATEST_WP_VERSION = "6.9.4";
+const LATEST_WP_VERSION = "7.0";
 const WASMER_PLUGIN_VERSION = "0.4.2";
 const WP_VERSION = process.env.WP_VERSION || "6.8.2";
 const PHP_VERSION = process.env.PHP_VERSION || "8.3";

--- a/wasmer/wasmer.php
+++ b/wasmer/wasmer.php
@@ -102,7 +102,7 @@ function wasmer_bypass_rest_api_auth_errors($result)
     return $result;
   }
 
-  if (str_starts_with($_GET['rest_route'], '/wasmer/v1/')) {
+  if (str_starts_with(get_query_var('rest_route'), '/wasmer/v1/')) {
     return true;
   }
 


### PR DESCRIPTION
Fix `Undefined array key "rest_route"` warnings in `wp-wasmer`.

The plugin was reading `$_GET['rest_route']` directly in the REST auth bypass check. That breaks on normal `/wp-json/...` requests where `rest_route` is resolved by WordPress but is not present in `$_GET`. On PHP 8+, this emits `Undefined array key` warnings.

Switch to `get_query_var('rest_route', '')` so the check uses WordPress’s parsed REST route instead of the raw query string.

Closes https://linear.app/wasmer/issue/BE-1429/new-phpix-apps-on-dev-return-rest-route-warning

UPD: Also bumped version in tests as they were failing